### PR TITLE
[FEAT] - Use helper to improve

### DIFF
--- a/src/Bitfinex.php
+++ b/src/Bitfinex.php
@@ -8,6 +8,7 @@ use EwertonDaniel\Bitfinex\Core\Builders\UrlBuilder;
 use EwertonDaniel\Bitfinex\Core\Services\BitfinexAuthenticated;
 use EwertonDaniel\Bitfinex\Core\Services\BitfinexPublic;
 use EwertonDaniel\Bitfinex\Core\ValueObjects\BitfinexCredentials;
+use EwertonDaniel\Bitfinex\Helpers\GetThis;
 use Exception;
 
 /**
@@ -20,7 +21,7 @@ use Exception;
  *
  * @email contact@ewertondaniel.work
  *
- * @version 1.0.0
+ * @version 0.1.1
  *
  * @since 2024-10-22
  *
@@ -54,7 +55,7 @@ class Bitfinex
      */
     final public function authenticated(?BitfinexCredentials $credentials = null): BitfinexAuthenticated
     {
-        $credentials = $credentials ?? new BitfinexCredentials;
+        $credentials = GetThis::ifTrueOrFallback(is_null($credentials), fn () => new BitfinexCredentials, $credentials);
 
         return new BitfinexAuthenticated(url: $this->urlBuilder->setBaseUrl('private'), credentials: $credentials);
     }

--- a/tests/Feature/BitfinexPublicTest.php
+++ b/tests/Feature/BitfinexPublicTest.php
@@ -26,6 +26,7 @@ test('Can retrieve bitfinex foreign exchange rate', function (Bitfinex $bitfinex
         'Euro/Dollar' => ['EUR', 'USD'],
         'Bitcoin/Dollar' => ['BTC', 'USD'],
         'Monero/Euro' => ['XMR', 'EUR'],
+        'Ethereum/Dollar' => ['ETH', 'USD'],
     ]);
 
 test('Can retrieve bitfinex tickers', function (Bitfinex $bitfinex) {


### PR DESCRIPTION
   **PASS  Tests\Feature\BitfinexPublicTest**
  _✓ Can retrieve bitfinex public class with dataset "Bitfinex Public"                                                                                                                                                                                          0.01s  
  ✓ Can retrieve bitfinex platform status with dataset "Bitfinex Public"                                                                                                                                                                                       0.45s  
  ✓ Can retrieve bitfinex ticker with dataset "Bitfinex Public" / dataset "Trading"                                                                                                                                                                            0.41s  
  ✓ Can retrieve bitfinex ticker with dataset "Bitfinex Public" / dataset "Funding"                                                                                                                                                                            0.41s  
  ✓ Can retrieve bitfinex foreign exchange rate with dataset "Bitfinex Public" / dataset "Euro/Dollar"                                                                                                                                                         0.41s  
  ✓ Can retrieve bitfinex foreign exchange rate with dataset "Bitfinex Public" / dataset "Bitcoin/Dollar"                                                                                                                                                      0.41s  
  ✓ Can retrieve bitfinex foreign exchange rate with dataset "Bitfinex Public" / dataset "Monero/Euro"                                                                                                                                                         0.35s  
  ✓ Can retrieve bitfinex foreign exchange rate with dataset "Bitfinex Public" / dataset "Ethereum/Dollar"                                                                                                                                                     0.35s  
  ✓ Can retrieve bitfinex tickers with dataset "Bitfinex Public" / dataset "Trading"                                                                                                                                                                           0.94s  
  ✓ Can retrieve bitfinex tickers with dataset "Bitfinex Public" / dataset "Funding"                                                                                                                                                                           0.14s  
  ✓ Can retrieve bitfinex ticker history with dataset "Bitfinex Public" / dataset "Euro/Dollar, Bitcoin/Dollar"                                                                                                                                                0.38s  
  ✓ Can retrieve bitfinex ticker history with dataset "Bitfinex Public" / dataset "Monero/Dollar, Ethereum/Dollar"                                                                                                                                             0.40s  
  ✓ Can retrieve bitfinex trades with dataset "Bitfinex Public" / dataset "Trading"                                                                                                                                                                            0.82s  
  ✓ Can retrieve bitfinex trades with dataset "Bitfinex Public" / dataset "Funding"                                                                                                                                                                            0.20s_  

  **Tests:    14 passed (14 assertions)
  Duration: 5.75s**
