### PR TITLE
[REFACTOR] - Separate methods to fetch order book data by currency and by pair

### DIFF
--- a/src/Enums/BitfinexType.php
+++ b/src/Enums/BitfinexType.php
@@ -70,4 +70,9 @@ enum BitfinexType: string
     {
         return $this === self::FUNDING;
     }
+
+    final public function symbols(array $items): string
+    {
+        return implode(',', array_map([$this, 'symbol'], $items));
+    }
 }

--- a/src/Helpers/DateToTimestamp.php
+++ b/src/Helpers/DateToTimestamp.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Helpers;
+
+use Carbon\Carbon;
+
+class DateToTimestamp
+{
+    /**
+     * Converts a date (string or Carbon) to a timestamp.
+     *
+     * @param  string|Carbon|int| null  $date  The date to be converted.
+     * @return int|null The corresponding timestamp, or null if the input is null.
+     */
+    final public static function convert(string|Carbon|int|null $date): ?int
+    {
+        if ($date instanceof Carbon) {
+            $date = $date->timestamp;
+        } elseif (is_string($date)) {
+            $date = Carbon::parse($date)->timestamp;
+        }
+
+        return $date;
+    }
+}

--- a/src/Helpers/GetThis.php
+++ b/src/Helpers/GetThis.php
@@ -56,7 +56,7 @@ class GetThis
      *
      * @return string The user's validated IP address or '0.0.0.0' if unavailable.
      */
-    public static function userIp(): string
+    final public static function userIp(): string
     {
         $ip = match (true) {
             ! empty($_SERVER['HTTP_CLIENT_IP']) => $_SERVER['HTTP_CLIENT_IP'],

--- a/src/Services/Authenticated/BitfinexAuthenticatedAccountAction.php
+++ b/src/Services/Authenticated/BitfinexAuthenticatedAccountAction.php
@@ -2,6 +2,7 @@
 
 namespace EwertonDaniel\Bitfinex\Services\Authenticated;
 
+use Carbon\Carbon;
 use EwertonDaniel\Bitfinex\Builders\RequestBuilder;
 use EwertonDaniel\Bitfinex\Builders\UrlBuilder;
 use EwertonDaniel\Bitfinex\Enums\BitfinexAction;
@@ -10,6 +11,7 @@ use EwertonDaniel\Bitfinex\Enums\BitfinexWalletType;
 use EwertonDaniel\Bitfinex\Enums\OrderOfferType;
 use EwertonDaniel\Bitfinex\Exceptions\BitfinexException;
 use EwertonDaniel\Bitfinex\Exceptions\BitfinexPathNotFoundException;
+use EwertonDaniel\Bitfinex\Helpers\DateToTimestamp;
 use EwertonDaniel\Bitfinex\Http\Requests\BitfinexRequest;
 use EwertonDaniel\Bitfinex\Http\Responses\AuthenticatedBitfinexResponse;
 use EwertonDaniel\Bitfinex\Http\Responses\BitfinexResponse;
@@ -103,9 +105,17 @@ class BitfinexAuthenticatedAccountAction
      *
      * @link https://docs.bitfinex.com/reference/rest-auth-logins-hist
      */
-    final public function loginHistory(): AuthenticatedBitfinexResponse
-    {
+    final public function loginHistory(
+        Carbon|string|null $start = null,
+        Carbon|string|null $end = null,
+        int $limit = 250
+    ): AuthenticatedBitfinexResponse {
         $request = new BitfinexRequest($this->request, $this->credentials, $this->client);
+
+        $params = ['start' => DateToTimestamp::convert($start), 'end' => DateToTimestamp::convert($end), 'limit' => $limit];
+
+        array_walk($params, fn ($value, $key) => $this->request->addBody($key, $value, true));
+
         $response = $request->execute(apiPath: $this->url->setPath("$this->basePath.login_history")->getPath());
 
         return $response->loginHistory();
@@ -142,9 +152,14 @@ class BitfinexAuthenticatedAccountAction
      *
      * @link https://docs.bitfinex.com/reference/rest-auth-audit-hist
      */
-    final public function changelog(): AuthenticatedBitfinexResponse
+    final public function changelog(Carbon|string|null $start = null, Carbon|string|null $end = null, int $limit = 250): AuthenticatedBitfinexResponse
     {
         $request = new BitfinexRequest($this->request, $this->credentials, $this->client);
+
+        $params = ['start' => DateToTimestamp::convert($start), 'end' => DateToTimestamp::convert($end), 'limit' => $limit];
+
+        array_walk($params, fn ($value, $key) => $this->request->addBody($key, $value, true));
+
         $response = $request->execute(apiPath: $this->url->setPath("$this->basePath.changelog")->getPath());
 
         return $response->changelog();
@@ -178,11 +193,7 @@ class BitfinexAuthenticatedAccountAction
      */
     final public function depositAddress(BitfinexWalletType $walletType, string $method, int $opRenew = 0): AuthenticatedBitfinexResponse
     {
-        $this->request->setBody([
-            'wallet' => $walletType->value,
-            'method' => $method,
-            'op_renew' => $opRenew,
-        ]);
+        $this->request->setBody(['wallet' => $walletType->value, 'method' => $method, 'op_renew' => $opRenew]);
 
         $request = new BitfinexRequest($this->request, $this->credentials, $this->client);
 

--- a/src/Services/Public/BitfinexPublicBook.php
+++ b/src/Services/Public/BitfinexPublicBook.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Services\Public;
+
+use EwertonDaniel\Bitfinex\Builders\UrlBuilder;
+use EwertonDaniel\Bitfinex\Enums\BitfinexType;
+use EwertonDaniel\Bitfinex\Enums\BookPrecision;
+use EwertonDaniel\Bitfinex\Exceptions\BitfinexException;
+use EwertonDaniel\Bitfinex\Helpers\GetThis;
+use EwertonDaniel\Bitfinex\Http\Responses\PublicBitfinexResponse;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+
+class BitfinexPublicBook
+{
+    /**
+     * @param  BookPrecision|null  $precision  The precision level for the order book data (e.g., P0, P1).
+     * @param  int|null  $length  The maximum number of price levels to retrieve (default: 25).
+     */
+    public function __construct(
+        private readonly Client $client,
+        private readonly UrlBuilder $url,
+        private ?BookPrecision $precision,
+        private readonly ?int $length = 25
+    ) {
+        $this->precision = GetThis::ifTrueOrFallback($precision, $this->precision, fn () => BookPrecision::R0);
+    }
+
+    /**
+     * Retrieves the order book data for a specified trading pair or funding currency.
+     *
+     * This method fetches real-time order book data for a given symbol and precision level.
+     * It allows specifying the maximum number of price levels to retrieve.
+     *
+     * @param  string  $symbol  The trading pair (e.g., tBTCUSD) or funding currency (e.g., fUSD).
+     * @param  BitfinexType  $type  The type of market (trading or funding).
+     * @return PublicBitfinexResponse Returns a response object containing the requested order book data.
+     *
+     * @throws BitfinexException If the API request fails or an unexpected error occurs.
+     *
+     * @link https://docs.bitfinex.com/reference/rest-public-books
+     */
+    protected function get(string $symbol, BitfinexType $type): PublicBitfinexResponse
+    {
+        try {
+            $apiPath = $this->url->setPath(path: 'public.book', params: ['symbol' => $symbol, 'precision' => $this->precision->name])->getPath();
+
+            $apiResponse = $this->client->get($apiPath, ['query' => ['len' => $this->length]]);
+
+            return (new PublicBitfinexResponse($apiResponse))->book($symbol, $type);
+        } catch (GuzzleException $e) {
+            throw new BitfinexException($e->getMessage(), $e->getCode());
+        }
+    }
+
+    /**
+     * Retrieves the order book data for a specific trading pair.
+     *
+     * Fetches the order book data for a given trading pair.
+     *
+     * @param  string  $pair  The trading pair symbol (e.g., tBTCUSD).
+     * @return PublicBitfinexResponse Returns a response object containing the requested order book data.
+     *
+     * @throws BitfinexException If the API request fails or an unexpected error occurs.
+     */
+    final public function byPair(string $pair): PublicBitfinexResponse
+    {
+        $type = BitfinexType::TRADING;
+        $symbol = $type->symbol($pair);
+
+        return $this->get(symbol: $symbol, type: $type);
+    }
+
+    /**
+     * Retrieves the order book data for a specific currency.
+     *
+     * Fetches the order book data for a given currency.
+     *
+     * @param  string  $currency  The currency symbol (e.g., USD, EUR).
+     * @return PublicBitfinexResponse Returns a response object containing the requested order book data.
+     *
+     * @throws BitfinexException If the API request fails or an unexpected error occurs.
+     */
+    final public function byCurrency(string $currency): PublicBitfinexResponse
+    {
+        $type = BitfinexType::FUNDING;
+        $symbol = $type->symbol($currency);
+
+        return $this->get(symbol: $symbol, type: $type);
+    }
+}

--- a/src/Services/Public/BitfinexPublicStats.php
+++ b/src/Services/Public/BitfinexPublicStats.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Services\Public;
+
+use Carbon\Carbon;
+use EwertonDaniel\Bitfinex\Builders\UrlBuilder;
+use EwertonDaniel\Bitfinex\Enums\BitfinexType;
+use EwertonDaniel\Bitfinex\Exceptions\BitfinexException;
+use EwertonDaniel\Bitfinex\Exceptions\BitfinexPathNotFoundException;
+use EwertonDaniel\Bitfinex\Helpers\DateToTimestamp;
+use EwertonDaniel\Bitfinex\Http\Responses\PublicBitfinexResponse;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+
+/**
+ * Class BitfinexPublicStats
+ *
+ * Provides access to statistical data from the Bitfinex API, including
+ * position sizes, funding sizes, and other platform-specific metrics.
+ * The class allows retrieving historical or real-time statistics
+ * based on configurable parameters.
+ *
+ * @author  Ewerton Daniel
+ *
+ * @contact contact@ewertondaniel.work
+ */
+class BitfinexPublicStats
+{
+    /**
+     * Constructor for the BitfinexPublicStats class.
+     *
+     * @param  Client  $client  Instance of Guzzle HTTP client for making API requests.
+     * @param  UrlBuilder  $url  Instance of UrlBuilder for constructing API paths.
+     * @param  string  $key  The type of statistic to retrieve (e.g., 'pos.size', 'funding.size').
+     * @param  string  $size  The interval or granularity of the data (e.g., '1m', '30m', '1d').
+     * @param  string  $sidePair  The side of the data (e.g., 'long', 'short'), or a pair for credits.
+     * @param  string  $section  Specifies whether to fetch the 'last' or 'hist' data section.
+     */
+    public function __construct(
+        private readonly Client $client,
+        private readonly UrlBuilder $url,
+        private readonly string $key,
+        private readonly string $size,
+        private readonly string $sidePair,
+        private readonly string $section
+    ) {}
+
+    /**
+     * Retrieves statistics from the platform's operational data based on specified parameters.
+     *
+     * This method fetches statistics from the Bitfinex API by constructing the appropriate URL
+     * with the provided key, size, symPlatform, sidePair, and section. It also allows additional
+     * query parameters such as sorting and filtering by start and end time.
+     *
+     * @param  string  $symPlatform  The trading pair or funding currency symbol.
+     * @param  ?int  $sort  [Optional] Sort order: +1 for ascending, -1 for descending.
+     * @param  ?int  $start  [Optional] Records with MTS >= start (milliseconds).
+     * @param  ?int  $end  [Optional] Records with MTS <= end (milliseconds).
+     * @param  ?int  $limit  [Optional] Maximum number of records (default: 100).
+     * @return PublicBitfinexResponse Returns a response object containing the requested statistics.
+     *
+     * @throws BitfinexException If the API request fails or an error occurs during processing.
+     * @throws BitfinexPathNotFoundException If the API path is not found.
+     *
+     * @link https://docs.bitfinex.com/reference/rest-public-stats
+     */
+    protected function get(string $symPlatform, ?int $sort, ?int $start, ?int $end, ?int $limit): PublicBitfinexResponse
+    {
+        try {
+            $apiPath = $this->url->setPath('public.stats_one', [
+                'key' => $this->key,
+                'size' => $this->size,
+                'sym_platform' => $symPlatform,
+                'side_pair' => $this->sidePair,
+                'section' => $this->section,
+            ])->getPath();
+
+            $apiResponse = $this->client->get($apiPath, [
+                'query' => array_filter([
+                    'sort' => $sort,
+                    'start' => $start,
+                    'end' => $end,
+                    'limit' => $limit,
+                ], fn ($value) => ! is_null($value)),
+            ]);
+
+            return (new PublicBitfinexResponse($apiResponse))->stats($this->key, $this->size, $symPlatform, $this->sidePair, $this->section);
+        } catch (GuzzleException $e) {
+            throw new BitfinexException($e->getMessage(), $e->getCode());
+        }
+    }
+
+    /**
+     * Retrieves statistics for a specific trading pair.
+     *
+     * @param  string  $pair  The trading pair symbol (e.g., tBTCUSD).
+     * @param  ?int  $sort  [Optional] Sort order: +1 for ascending, -1 for descending.
+     * @param  Carbon|string|null  $start  [Optional] Start time (as Carbon instance or string).
+     * @param  Carbon|string|null  $end  [Optional] End time (as Carbon instance or string).
+     * @param  ?int  $limit  [Optional] Maximum number of records to retrieve.
+     * @return PublicBitfinexResponse Returns a response object containing the requested statistics.
+     *
+     * @throws BitfinexException If the API request fails or an error occurs during processing.
+     */
+    final public function byPair(
+        string $pair,
+        ?int $sort = null,
+        Carbon|string|null $start = null,
+        Carbon|string|null $end = null,
+        ?int $limit = null
+    ): PublicBitfinexResponse {
+        $type = BitfinexType::TRADING;
+
+        $symPlatform = $type->symbol($pair);
+
+        return $this->get(
+            symPlatform: $symPlatform,
+            sort: $sort,
+            start: DateToTimestamp::convert($start),
+            end: DateToTimestamp::convert($end),
+            limit: $limit
+        );
+    }
+
+    /**
+     * Retrieves statistics for a specific funding currency.
+     *
+     * @param  string  $currency  The funding currency symbol (e.g., USD, EUR).
+     * @param  ?int  $sort  [Optional] Sort order: +1 for ascending, -1 for descending.
+     * @param  Carbon|string|null  $start  [Optional] Start time (as Carbon instance or string).
+     * @param  Carbon|string|null  $end  [Optional] End time (as Carbon instance or string).
+     * @param  ?int  $limit  [Optional] Maximum number of records to retrieve.
+     * @return PublicBitfinexResponse Returns a response object containing the requested statistics.
+     *
+     * @throws BitfinexException If the API request fails or an error occurs during processing.
+     * @throws BitfinexPathNotFoundException If the API path is not found.
+     */
+    final public function byCurrency(
+        string $currency,
+        ?int $sort = null,
+        Carbon|string|null $start = null,
+        Carbon|string|null $end = null,
+        ?int $limit = null
+    ): PublicBitfinexResponse {
+        $type = BitfinexType::FUNDING;
+
+        $symPlatform = $type->symbol($currency);
+
+        return $this->get(
+            symPlatform: $symPlatform,
+            sort: $sort,
+            start: DateToTimestamp::convert($start),
+            end: DateToTimestamp::convert($end),
+            limit: $limit
+        );
+    }
+}

--- a/src/Services/Public/BitfinexPublicTicker.php
+++ b/src/Services/Public/BitfinexPublicTicker.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Services\Public;
+
+use EwertonDaniel\Bitfinex\Builders\UrlBuilder;
+use EwertonDaniel\Bitfinex\Enums\BitfinexType;
+use EwertonDaniel\Bitfinex\Exceptions\BitfinexException;
+use EwertonDaniel\Bitfinex\Exceptions\BitfinexPathNotFoundException;
+use EwertonDaniel\Bitfinex\Http\Responses\PublicBitfinexResponse;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+
+/**
+ * Class BitfinexPublicTicker
+ *
+ * Provides access to Bitfinex public ticker data, including real-time and historical
+ * market data for trading pairs and funding currencies.
+ *
+ * @author  Ewerton Daniel
+ *
+ * @contact contact@ewertondaniel.work
+ */
+class BitfinexPublicTicker
+{
+    /**
+     * Constructor for the BitfinexPublicTicker class.
+     *
+     * Initializes the service with a Guzzle HTTP client and a URL builder.
+     *
+     * @param  Client  $client  Instance of Guzzle HTTP client for making API requests.
+     * @param  UrlBuilder  $url  Instance of UrlBuilder for constructing API paths.
+     */
+    public function __construct(private readonly Client $client, private readonly UrlBuilder $url) {}
+
+    /**
+     * Retrieves the latest state of multiple markets (tickers) based on provided symbols.
+     *
+     * @param  string  $symbols  Comma-separated list of symbols (e.g., "tBTCUSD,fUSD").
+     * @param  BitfinexType  $type  The type of market (trading or funding).
+     * @return PublicBitfinexResponse Response containing the tickers for the requested symbols.
+     *
+     * @throws BitfinexException If the API request fails or an unexpected error occurs.
+     * @throws BitfinexPathNotFoundException If the API path is not found.
+     *
+     * @link https://docs.bitfinex.com/reference/rest-public-tickers
+     */
+    protected function get(string $symbols, BitfinexType $type): PublicBitfinexResponse
+    {
+        try {
+            $apiPath = $this->url->setPath(path: 'public.tickers')->getPath();
+
+            $options = ['query' => ['symbols' => $symbols]];
+
+            $apiResponse = $this->client->get($apiPath, $options);
+
+            return (new PublicBitfinexResponse($apiResponse))->tickers($type);
+        } catch (GuzzleException $e) {
+            throw new BitfinexException($e->getMessage(), $e->getCode());
+        }
+    }
+
+    /**
+     * Retrieves the latest state of all funding currencies.
+     *
+     * @param  array  $currencies  List of currencies (e.g., ["USD", "EUR"]).
+     * @return PublicBitfinexResponse Response containing tickers for the specified currencies.
+     *
+     * @throws BitfinexPathNotFoundException If the API path is not found.
+     * @throws BitfinexException If the API request fails or an unexpected error occurs.
+     */
+    final public function byCurrencies(array $currencies): PublicBitfinexResponse
+    {
+        $type = BitfinexType::FUNDING;
+        $symbols = $type->symbols($currencies);
+
+        return $this->get(symbols: $symbols, type: $type);
+    }
+
+    /**
+     * Retrieves the latest state of all trading pairs.
+     *
+     * @param  array  $pairs  List of trading pairs (e.g., ["tBTCUSD", "tETHUSD"]).
+     * @return PublicBitfinexResponse Response containing tickers for the specified trading pairs.
+     *
+     * @throws BitfinexPathNotFoundException If the API path is not found.
+     * @throws BitfinexException If the API request fails or an unexpected error occurs.
+     */
+    final public function byPairs(array $pairs): PublicBitfinexResponse
+    {
+        $type = BitfinexType::FUNDING;
+        $symbols = $type->symbols($pairs);
+
+        return $this->get(symbols: $symbols, type: $type);
+    }
+
+    /**
+     * Retrieves market data for a specific trading pair or funding currency.
+     *
+     * @param  string  $symbol  The trading pair (e.g., tBTCUSD) or funding currency (e.g., fUSD).
+     * @param  BitfinexType|string  $type  The type of market (trading or funding).
+     * @return PublicBitfinexResponse Response containing ticker data for the specified symbol.
+     *
+     * @throws BitfinexException If the API request fails or an unexpected error occurs.
+     *
+     * @link https://docs.bitfinex.com/reference/rest-public-ticker
+     */
+    protected function ticker(string $symbol, BitfinexType|string $type): PublicBitfinexResponse
+    {
+        try {
+            $apiPath = $this->url->setPath(path: 'public.ticker', params: ['symbol' => $symbol])->getPath();
+
+            $apiResponse = $this->client->get($apiPath);
+
+            return (new PublicBitfinexResponse($apiResponse))->ticker($symbol, $type);
+        } catch (GuzzleException $e) {
+            throw new BitfinexException($e->getMessage(), $e->getCode());
+        }
+    }
+
+    /**
+     * Retrieves ticker data for a specific trading pair.
+     *
+     * @param  string  $pair  The trading pair symbol (e.g., tBTCUSD).
+     * @return PublicBitfinexResponse Response containing ticker data for the trading pair.
+     *
+     * @throws BitfinexException If the API request fails or an unexpected error occurs.
+     */
+    final public function byPair(string $pair): PublicBitfinexResponse
+    {
+        $type = BitfinexType::TRADING;
+
+        return $this->ticker(symbol: $type->symbol($pair), type: $type);
+    }
+
+    /**
+     * Retrieves ticker data for a specific funding currency.
+     *
+     * @param  string  $currency  The currency symbol (e.g., USD, EUR).
+     * @return PublicBitfinexResponse Response containing ticker data for the currency.
+     *
+     * @throws BitfinexException If the API request fails or an unexpected error occurs.
+     */
+    final public function byCurrency(string $currency): PublicBitfinexResponse
+    {
+        $type = BitfinexType::FUNDING;
+
+        return $this->ticker(symbol: $type->symbol($currency), type: $type);
+    }
+
+    /**
+     * Retrieves historical ticker data for a list of trading pairs.
+     *
+     * @param  array  $pairs  List of trading pairs (e.g., ["tBTCUSD", "tETHUSD"]).
+     * @param  int  $limit  Maximum number of records to fetch (default: 100).
+     * @param  string|null  $start  Start timestamp in milliseconds (optional).
+     * @param  string|null  $end  End timestamp in milliseconds (optional).
+     * @return PublicBitfinexResponse Response containing historical ticker data.
+     *
+     * @throws BitfinexException If the API request fails or an unexpected error occurs.
+     *
+     * @link https://docs.bitfinex.com/reference/rest-public-ticker-history
+     */
+    final public function history(array $pairs, int $limit = 100, ?string $start = null, ?string $end = null): PublicBitfinexResponse
+    {
+        try {
+            $apiPath = $this->url->setPath(path: 'public.ticker_history')->getPath();
+
+            $apiResponse = $this->client->get($apiPath, [
+                'query' => [
+                    'symbols' => BitfinexType::TRADING->symbols($pairs),
+                    'limit' => $limit,
+                    'start' => $start,
+                    'end' => $end,
+                ],
+            ]);
+
+            return (new PublicBitfinexResponse($apiResponse))->tickerHistory();
+        } catch (GuzzleException $e) {
+            throw new BitfinexException($e->getMessage(), $e->getCode());
+        }
+    }
+}

--- a/src/Services/Public/BitfinexPublicTrade.php
+++ b/src/Services/Public/BitfinexPublicTrade.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Services\Public;
+
+use Carbon\Carbon;
+use EwertonDaniel\Bitfinex\Builders\UrlBuilder;
+use EwertonDaniel\Bitfinex\Enums\BitfinexType;
+use EwertonDaniel\Bitfinex\Exceptions\BitfinexException;
+use EwertonDaniel\Bitfinex\Helpers\DateToTimestamp;
+use EwertonDaniel\Bitfinex\Http\Responses\PublicBitfinexResponse;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+
+/**
+ * Class BitfinexPublicTrade
+ *
+ * Provides functionality for accessing Bitfinex public trade data.
+ * This class supports retrieving historical trade data for specific symbols,
+ * filtering by date range, sorting, and limiting the number of results.
+ *
+ * @author  Ewerton Daniel
+ *
+ * @contact contact@ewertondaniel.work
+ */
+class BitfinexPublicTrade
+{
+    private readonly ?int $start;
+
+    private readonly ?int $end;
+
+    /**
+     * @param  Client  $client  Instance of Guzzle HTTP client for making requests.
+     * @param  UrlBuilder  $url  Instance of UrlBuilder for constructing API paths.
+     * @param  int  $limit  Number of records to retrieve (default: 125).
+     * @param  int  $sort  Sort order: +1 (ascending), -1 (descending).
+     * @param  Carbon|string|null  $start  Start date or timestamp for filtering results (optional).
+     * @param  Carbon|string|null  $end  End date or timestamp for filtering results (optional).
+     */
+    public function __construct(
+        private readonly Client $client,
+        private readonly UrlBuilder $url,
+        private readonly int $limit,
+        private readonly int $sort,
+        Carbon|string|null $start,
+        Carbon|string|null $end
+    ) {
+        $this->start = DateToTimestamp::convert($start);
+        $this->end = DateToTimestamp::convert($end);
+    }
+
+    /**
+     * Retrieves historical trade data for a given symbol.
+     *
+     * This method fetches public trade data for a specified trading pair or currency.
+     * It supports pagination, sorting, and filtering using timestamps.
+     *
+     * @param  string  $symbol  Trading pair or currency symbol (e.g., tBTCUSD, fUSD).
+     * @param  BitfinexType  $type  The type of trade data (e.g., trading or funding).
+     * @return PublicBitfinexResponse A structured response containing trade data.
+     *
+     * @throws BitfinexException If the request fails or an error occurs during processing.
+     *
+     * @link https://docs.bitfinex.com/reference/rest-public-trades
+     */
+    protected function get(string $symbol, BitfinexType $type): PublicBitfinexResponse
+    {
+        try {
+            $apiPath = $this->url->setPath(path: 'public.trades', params: ['symbol' => $symbol])->getPath();
+
+            $apiResponse = $this->client->get(
+                uri: $apiPath,
+                options: [
+                    'query' => [
+                        'limit' => $this->limit,
+                        'sort' => $this->sort,
+                        'start' => $this->start,
+                        'end' => $this->end,
+                    ],
+                ]
+            );
+
+            return (new PublicBitfinexResponse($apiResponse))->trades(symbol: $symbol, type: $type);
+
+        } catch (GuzzleException $e) {
+            throw new BitfinexException($e->getMessage(), $e->getCode());
+        }
+    }
+
+    /**
+     * Retrieves trade data for a specific currency.
+     *
+     * Fetches funding trade data using the given currency symbol.
+     *
+     * @param  string  $currency  The currency symbol (e.g., USD, EUR).
+     * @return PublicBitfinexResponse A structured response containing trade data.
+     *
+     * @throws BitfinexException If the request fails or an error occurs during processing.
+     */
+    final public function byCurrency(string $currency): PublicBitfinexResponse
+    {
+        $type = BitfinexType::FUNDING;
+        $symbol = $type->symbol($currency);
+
+        return $this->get(symbol: $symbol, type: $type);
+    }
+
+    /**
+     * Retrieves trade data for a specific trading pair.
+     *
+     * Fetches trading data using the given trading pair symbol.
+     *
+     * @param  string  $pair  The trading pair symbol (e.g., BTCUSD).
+     * @return PublicBitfinexResponse A structured response containing trade data.
+     *
+     * @throws BitfinexException If the request fails or an error occurs during processing.
+     */
+    final public function byPair(string $pair): PublicBitfinexResponse
+    {
+        $type = BitfinexType::TRADING;
+        $symbol = $type->symbol($pair);
+
+        return $this->get(symbol: $symbol, type: $type);
+    }
+}

--- a/tests/Datasets/bitfinex.php
+++ b/tests/Datasets/bitfinex.php
@@ -23,12 +23,12 @@ dataset('Movement Id', [
     'id' => '123456789',  // <= It's a fake value //
 ]);
 
-dataset('Pair and Type', [
+dataset('Pair/Currency and Type', [
     'Trading' => ['XMRUST', BitfinexType::TRADING],
     'Funding' => ['XMR', BitfinexType::FUNDING],
 ]);
 
-dataset('Pairs and Type', [
+dataset('Pairs/Currencies and Type', [
     'Trading' => [['XMRUST', 'EURUSD'], BitfinexType::TRADING],
     'Funding' => [['UST', 'USD'], BitfinexType::FUNDING],
 ]);

--- a/tests/Feature/BitfinexAuthenticatedWalletTest.php
+++ b/tests/Feature/BitfinexAuthenticatedWalletTest.php
@@ -4,12 +4,11 @@ use EwertonDaniel\Bitfinex\Bitfinex;
 use EwertonDaniel\Bitfinex\Http\Responses\BitfinexResponse;
 use EwertonDaniel\Bitfinex\ValueObjects\BitfinexCredentials;
 
-/** @link https://docs.bitfinex.com/reference/rest-auth-wallets */
 test('Should Retrieve Orders', function (BitfinexCredentials $credentials, Bitfinex $bitfinex) {
 
     $authenticated = $bitfinex->authenticated($credentials)->generateToken();
     $response = $authenticated->wallets()->get();
-    dd($response);
-    expect($response)->toBeInstanceOf(BitfinexResponse::class);
+
+    expect($response)->toBeInstanceOf(BitfinexResponse::class)->dump();
 
 })->with('Auth')->with('Bitfinex');

--- a/tests/Feature/BitfinexPublicTest.php
+++ b/tests/Feature/BitfinexPublicTest.php
@@ -2,7 +2,6 @@
 
 use EwertonDaniel\Bitfinex\Bitfinex;
 use EwertonDaniel\Bitfinex\Enums\BitfinexType;
-use EwertonDaniel\Bitfinex\Enums\BookPrecision;
 use EwertonDaniel\Bitfinex\Http\Responses\PublicBitfinexResponse;
 use EwertonDaniel\Bitfinex\Services\BitfinexPublic;
 
@@ -11,39 +10,47 @@ test('Should retrieve bitfinex public class', function (Bitfinex $bitfinex) {
 })->with(['Bitfinex Public' => fn () => new Bitfinex]);
 
 test('Should retrieve bitfinex platform status', function (Bitfinex $bitfinex) {
-    expect($bitfinex->public()->platformStatus())
-        ->toBeInstanceOf(PublicBitfinexResponse::class);
+    expect($bitfinex->public()->platformStatus())->toBeInstanceOf(PublicBitfinexResponse::class);
 })->with('Bitfinex');
 
 test('Should retrieve bitfinex ticker', function (Bitfinex $bitfinex, string $symbol, BitfinexType $type) {
-    expect($bitfinex->public()->ticker($symbol, $type))
-        ->toBeInstanceOf(PublicBitfinexResponse::class);
-})->with('Bitfinex')->with('Pair and Type');
+    $expected = $type->isFunding() ? $bitfinex->public()->ticker()->byCurrency($symbol) : $bitfinex->public()->ticker()->byPair($symbol);
 
-test('Should retrieve bitfinex tickers', function (Bitfinex $bitfinex, array $pairs, BitfinexType $type) {
-    expect($bitfinex->public()->tickers($pairs, $type))
-        ->toBeInstanceOf(PublicBitfinexResponse::class);
-})->with('Bitfinex')->with('Pairs and Type');
+    expect($expected)->toBeInstanceOf(PublicBitfinexResponse::class);
+})->with('Bitfinex')->with('Pair/Currency and Type');
+
+test('Should retrieve bitfinex tickers', function (Bitfinex $bitfinex, array $symbols, BitfinexType $type) {
+    $expected = $type->isFunding() ? $bitfinex->public()->ticker()->byCurrencies($symbols) : $bitfinex->public()->ticker()->byPairs($symbols);
+
+    expect($expected)->toBeInstanceOf(PublicBitfinexResponse::class);
+})->with('Bitfinex')->with('Pairs/Currencies and Type');
 
 test('Should retrieve bitfinex ticker history', function (Bitfinex $bitfinex, array $pairs) {
-    expect($bitfinex->public()->tickerHistory($pairs))
-        ->toBeInstanceOf(PublicBitfinexResponse::class);
+    expect($bitfinex->public()->ticker()->history($pairs))->toBeInstanceOf(PublicBitfinexResponse::class);
 })->with('Bitfinex')->with('Pairs');
 
 test('Should retrieve bitfinex trades', function (Bitfinex $bitfinex, $symbol, BitfinexType $type) {
-    expect($bitfinex->public()->trades($symbol, $type))
-        ->toBeInstanceOf(PublicBitfinexResponse::class);
-})->with('Bitfinex')->with('Pair and Type');
+    $trades = $bitfinex->public()->trades();
+
+    $expected = $type->isFunding() ? $trades->byCurrency($symbol) : $trades->byPair($symbol);
+
+    expect($expected)->toBeInstanceOf(PublicBitfinexResponse::class);
+})->with('Bitfinex')->with('Pair/Currency and Type');
 
 test('Should retrieve bitfinex book', function (Bitfinex $bitfinex, $symbol, BitfinexType $type) {
-    expect($bitfinex->public()->book($symbol, $type, BookPrecision::R0))
-        ->toBeInstanceOf(PublicBitfinexResponse::class);
-})->with('Bitfinex')->with('Pair and Type');
+    $book = $bitfinex->public()->book();
 
-test('Should retrieve bitfinex stats', function (Bitfinex $bitfinex) {
-    expect($bitfinex->public()->stats(key: 'pos.size', size: '1m', type: BitfinexType::TRADING, pair: 'BTCUSD', sidePair: 'long', section: 'hist'))
-        ->toBeInstanceOf(PublicBitfinexResponse::class);
-})->with('Bitfinex');
+    $expected = $type->isFunding() ? $book->byCurrency($symbol) : $book->byPair($symbol);
+
+    expect($expected)->toBeInstanceOf(PublicBitfinexResponse::class);
+})->with('Bitfinex')->with('Pair/Currency and Type');
+
+test('Should retrieve bitfinex stats', function (Bitfinex $bitfinex, $symbol, BitfinexType $type) {
+    $stats = $bitfinex->public()->stats(key: 'pos.size', size: '1m', sidePair: 'long', section: 'hist');
+    $expected = $type->isFunding() ? $stats->byCurrency($symbol) : $stats->byPair($symbol);
+
+    expect($expected)->toBeInstanceOf(PublicBitfinexResponse::class);
+})->with('Bitfinex')->with('Pair/Currency and Type');
 
 test('Should retrieve candles', function (Bitfinex $bitfinex) {
     /** @todo */
@@ -78,6 +85,5 @@ test('Should retrieve market average price', function (Bitfinex $bitfinex) {
 })->with('Bitfinex')->skip();
 
 test('Should retrieve bitfinex foreign exchange rate', function (Bitfinex $bitfinex, $baseCurrency, $quoteCurrency) {
-    expect($bitfinex->public()->foreignExchangeRate($baseCurrency, $quoteCurrency))
-        ->toBeInstanceOf(PublicBitfinexResponse::class);
+    expect($bitfinex->public()->foreignExchangeRate($baseCurrency, $quoteCurrency))->toBeInstanceOf(PublicBitfinexResponse::class);
 })->with('Bitfinex')->with('Currencies');


### PR DESCRIPTION
- Added `byPair` method for fetching trading pair order book data.
- Added `byCurrency` method for fetching funding currency order book data.
- Updated the `get` method to support both approaches.