### PR TITLE
[CHORE] - Prevent identifier duplication in symbol function

### DIFF
--- a/src/Enums/BitfinexType.php
+++ b/src/Enums/BitfinexType.php
@@ -2,6 +2,8 @@
 
 namespace EwertonDaniel\Bitfinex\Enums;
 
+use EwertonDaniel\Bitfinex\Helpers\GetThis;
+
 /**
  * Enum BitfinexType
  *
@@ -29,8 +31,16 @@ enum BitfinexType: string
     final public function symbol(string $pairOrCurrency): string
     {
         return match ($this) {
-            self::TRADING => "t$pairOrCurrency",
-            self::FUNDING => "f$pairOrCurrency",
+            self::TRADING => GetThis::ifTrueOrFallback(
+                boolean: str_starts_with($pairOrCurrency, 't'),
+                callback: fn () => $pairOrCurrency,
+                fallback: fn () => "t$pairOrCurrency",
+            ),
+            self::FUNDING => GetThis::ifTrueOrFallback(
+                boolean: str_starts_with($pairOrCurrency, 'f'),
+                callback: fn () => $pairOrCurrency,
+                fallback: fn () => "f$pairOrCurrency",
+            ),
         };
     }
 


### PR DESCRIPTION
- Added a check to avoid duplicating the 't' or 'f' prefix when generating symbols.
- Refactored the method to use GetThis::ifTrueOrFallback for cleaner logic.