### PR TITLE
Add TransformerFactory and unit tests for public transformers

### DIFF
--- a/src/Http/Responses/Public/TransformerFactory.php
+++ b/src/Http/Responses/Public/TransformerFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Http\Responses\Public;
+
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Contracts\PublicTransformer;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Transformers\BookTransformer;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Transformers\CandlesTransformer;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Transformers\DerivativesStatusTransformer;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Transformers\ForeignExchangeRateTransformer;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Transformers\FundingStatsTransformer;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Transformers\LeaderboardsTransformer;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Transformers\LiquidationsTransformer;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Transformers\MarketAveragePriceTransformer;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Transformers\PlatformStatusTransformer;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Transformers\StatsTransformer;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Transformers\TickerHistoryTransformer;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Transformers\TickerTransformer;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Transformers\TickersTransformer;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Transformers\TradesTransformer;
+
+class TransformerFactory
+{
+    public function make(string $name): PublicTransformer
+    {
+        return match ($name) {
+            'platformStatus' => new PlatformStatusTransformer(),
+            'ticker' => new TickerTransformer(),
+            'tickers' => new TickersTransformer(),
+            'tickerHistory' => new TickerHistoryTransformer(),
+            'foreignExchangeRate' => new ForeignExchangeRateTransformer(),
+            'trades' => new TradesTransformer(),
+            'book' => new BookTransformer(),
+            'stats' => new StatsTransformer(),
+            'candles' => new CandlesTransformer(),
+            'derivativesStatus' => new DerivativesStatusTransformer(),
+            'liquidations' => new LiquidationsTransformer(),
+            'leaderboards' => new LeaderboardsTransformer(),
+            'fundingStats' => new FundingStatsTransformer(),
+            'marketAveragePrice' => new MarketAveragePriceTransformer(),
+            default => new PlatformStatusTransformer(),
+        };
+    }
+}

--- a/tests/Unit/Public/TransformerFactoryTest.php
+++ b/tests/Unit/Public/TransformerFactoryTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use EwertonDaniel\Bitfinex\Http\Responses\Public\TransformerFactory;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Contracts\PublicTransformer;
+
+test('TransformerFactory resolves transformers by name', function () {
+    $factory = app(TransformerFactory::class);
+    $names = [
+        'platformStatus', 'ticker', 'tickers', 'tickerHistory', 'foreignExchangeRate',
+        'trades', 'book', 'stats', 'candles', 'derivativesStatus', 'liquidations',
+        'leaderboards', 'fundingStats', 'marketAveragePrice',
+    ];
+
+    foreach ($names as $name) {
+        $t = $factory->make($name);
+        expect($t)->toBeInstanceOf(PublicTransformer::class);
+    }
+});


### PR DESCRIPTION
### Description of Changes

- Implemented `TransformerFactory` for resolving public transformers by name.
  - Supported transformers include `platformStatus`, `ticker`, `tickers`, `candles`, and others.
  - Added a default fallback to `PlatformStatusTransformer` for unsupported names.
- Added unit tests in `TransformerFactoryTest` to verify that all supported names resolve correctly to `PublicTransformer` instances.

### Checklist

- [ ] Unit tests added/updated for changes.
- [ ] Documentation updated (if applicable).
- [ ] Verified functionality locally.
- [ ] Associated issues referenced (if applicable).