### PR TITLE
Add public transformers and merchant services

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4880faa65702253b8f40eaaabe9f4fc0",
+    "content-hash": "e4b633a01b2d3cbc5e6a48892bfc4ba6",
     "packages": [
         {
             "name": "brick/math",

--- a/src/Http/Responses/Configs/ConfigsTransformer.php
+++ b/src/Http/Responses/Configs/ConfigsTransformer.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Http\Responses\Configs;
+
+use EwertonDaniel\Bitfinex\Entities\ConfigEntry;
+use EwertonDaniel\Bitfinex\Http\Responses\Configs\Transformers\DefaultTransformer;
+use EwertonDaniel\Bitfinex\Http\Responses\Configs\Transformers\ListTransformer;
+use EwertonDaniel\Bitfinex\Http\Responses\Configs\Transformers\MapTransformer;
+use EwertonDaniel\Bitfinex\Http\Responses\Configs\Transformers\PairInfoTransformer;
+use EwertonDaniel\Bitfinex\Http\Responses\Configs\Transformers\TxStatusTransformer;
+
+class ConfigsTransformer
+{
+    public function __construct(
+        private readonly array $strategies = [
+            new MapTransformer(),
+            new ListTransformer(),
+            new PairInfoTransformer(),
+            new TxStatusTransformer(),
+            new DefaultTransformer(),
+        ]
+    ) {}
+
+    /**
+     * @param array<int,string> $keys
+     * @param mixed $content
+     * @return array{configs: array<int, ConfigEntry>}
+     */
+    public function transform(array $keys, mixed $content): array
+    {
+        $entries = [];
+        foreach ($keys as $i => $key) {
+            if (!is_array($content) || !array_key_exists($i, $content) || $content[$i] === null) {
+                continue;
+            }
+            $value = $content[$i];
+            foreach ($this->strategies as $t) {
+                if ($t->supports($key, $value)) {
+                    $value = $t->transform($key, $value);
+                    break;
+                }
+            }
+            $entries[] = new ConfigEntry($key, $value);
+        }
+        return ['configs' => $entries];
+    }
+}

--- a/src/Http/Responses/Configs/Contracts/ConfigTransformer.php
+++ b/src/Http/Responses/Configs/Contracts/ConfigTransformer.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Http\Responses\Configs\Contracts;
+
+/**
+ * Contract for configs transformers.
+ */
+interface ConfigTransformer
+{
+    public function supports(string $key, mixed $value): bool;
+
+    /**
+     * @param array $context Contextual parameters (e.g., symbol, type).
+     * @param mixed $content Decoded response content.
+     * @return mixed Transformed payload.
+     */
+    public function transform(string $key, mixed $value): mixed;
+}

--- a/src/Http/Responses/Configs/Transformers/DefaultTransformer.php
+++ b/src/Http/Responses/Configs/Transformers/DefaultTransformer.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Http\Responses\Configs\Transformers;
+
+use EwertonDaniel\Bitfinex\Http\Responses\Configs\Contracts\ConfigTransformer;
+
+/**
+ * Fallback transformer (identity).
+ */
+
+class DefaultTransformer implements ConfigTransformer
+{
+    public function supports(string $key, mixed $value): bool
+    {
+        return true; // Fallback
+    }
+
+    /**
+     * @param array $context Contextual parameters.
+     * @param mixed $content Decoded response content.
+     * @return mixed Returns original value.
+     */
+    public function transform(string $key, mixed $value): mixed
+    {
+        return $value;
+    }
+}

--- a/src/Http/Responses/Configs/Transformers/ListTransformer.php
+++ b/src/Http/Responses/Configs/Transformers/ListTransformer.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Http\Responses\Configs\Transformers;
+
+use EwertonDaniel\Bitfinex\Http\Responses\Configs\Contracts\ConfigTransformer;
+
+/**
+ * Normalizes list mode to list of strings.
+ */
+
+class ListTransformer implements ConfigTransformer
+{
+    public function supports(string $key, mixed $value): bool
+    {
+        return str_starts_with($key, 'pub:list:') && is_array($value);
+    }
+
+    /**
+     * @param array $context Contextual parameters.
+     * @param mixed $content Decoded response content.
+     * @return mixed Returns list<string>.
+     */
+    public function transform(string $key, mixed $value): mixed
+    {
+        return array_values(array_map(fn ($v) => is_array($v) ? (string) ($v[0] ?? '') : (string) $v, $value));
+    }
+}

--- a/src/Http/Responses/Configs/Transformers/MapTransformer.php
+++ b/src/Http/Responses/Configs/Transformers/MapTransformer.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Http\Responses\Configs\Transformers;
+
+use EwertonDaniel\Bitfinex\Http\Responses\Configs\Contracts\ConfigTransformer;
+
+/**
+ * Maps [[k,v],...] to associative dict.
+ */
+
+class MapTransformer implements ConfigTransformer
+{
+    public function supports(string $key, mixed $value): bool
+    {
+        return str_starts_with($key, 'pub:map:') && is_array($value);
+    }
+
+    /**
+     * @param array $context Contextual parameters.
+     * @param mixed $content Decoded response content.
+     * @return mixed Returns dict<string,mixed>.
+     */
+    public function transform(string $key, mixed $value): mixed
+    {
+        $map = [];
+        foreach ($value as $pair) {
+            if (is_array($pair) && count($pair) >= 2) {
+                $map[(string) $pair[0]] = $pair[1];
+            }
+        }
+        return $map;
+    }
+}

--- a/src/Http/Responses/Configs/Transformers/PairInfoTransformer.php
+++ b/src/Http/Responses/Configs/Transformers/PairInfoTransformer.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Http\Responses\Configs\Transformers;
+
+use EwertonDaniel\Bitfinex\Entities\PairInfo;
+use EwertonDaniel\Bitfinex\Http\Responses\Configs\Contracts\ConfigTransformer;
+
+/**
+ * Maps pair info rows to PairInfo.
+ */
+
+class PairInfoTransformer implements ConfigTransformer
+{
+    public function supports(string $key, mixed $value): bool
+    {
+        return str_starts_with($key, 'pub:info:pair') && is_array($value) && !empty($value);
+    }
+
+    /**
+     * @param array $context Contextual parameters.
+     * @param mixed $content Decoded response content.
+     * @return mixed Returns list<PairInfo>.
+     */
+    public function transform(string $key, mixed $value): mixed
+    {
+        return array_map(fn ($row) => new PairInfo($row), $value);
+    }
+}

--- a/src/Http/Responses/Configs/Transformers/TxStatusTransformer.php
+++ b/src/Http/Responses/Configs/Transformers/TxStatusTransformer.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Http\Responses\Configs\Transformers;
+
+use EwertonDaniel\Bitfinex\Entities\TxStatus;
+use EwertonDaniel\Bitfinex\Http\Responses\Configs\Contracts\ConfigTransformer;
+
+/**
+ * Maps tx status rows to TxStatus.
+ */
+
+class TxStatusTransformer implements ConfigTransformer
+{
+    public function supports(string $key, mixed $value): bool
+    {
+        return $key === 'pub:info:tx:status' && is_array($value) && !empty($value);
+    }
+
+    /**
+     * @param array $context Contextual parameters.
+     * @param mixed $content Decoded response content.
+     * @return mixed Returns list<TxStatus>.
+     */
+    public function transform(string $key, mixed $value): mixed
+    {
+        return array_map(fn ($row) => new TxStatus($row), $value);
+    }
+}

--- a/src/Http/Responses/Public/Contracts/PublicTransformer.php
+++ b/src/Http/Responses/Public/Contracts/PublicTransformer.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Http\Responses\Public\Contracts;
+
+/**
+ * Contract for public response transformers.
+ */
+interface PublicTransformer
+{
+    /**
+     * @param array $context Extra params needed by the transformer (e.g., symbol, type).
+     * @param mixed $content Raw decoded response content.
+     * @return mixed Transformed payload.
+     */
+    /**
+     * @param array $context Contextual parameters (e.g., symbol, type).
+     * @param mixed $content Decoded response content.
+     * @return mixed Transformed payload.
+     */
+    public function transform(array $context, mixed $content): mixed;
+}

--- a/src/Http/Responses/Public/Transformers/BookTransformer.php
+++ b/src/Http/Responses/Public/Transformers/BookTransformer.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Http\Responses\Public\Transformers;
+
+use EwertonDaniel\Bitfinex\Entities\BookFunding;
+use EwertonDaniel\Bitfinex\Entities\BookTrading;
+use EwertonDaniel\Bitfinex\Enums\BitfinexType;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Contracts\PublicTransformer;
+
+/**
+ * Maps book rows to BookTrading/BookFunding.
+ */
+
+class BookTransformer implements PublicTransformer
+{
+    /**
+     * @param array $context Contextual parameters.
+     * @param mixed $content Decoded response content.
+     * @return mixed Returns array{symbol: string, books: list<Book*>}.
+     */
+    public function transform(array $context, mixed $content): mixed
+    {
+        $symbol = (string) ($context['symbol'] ?? '');
+        $type = $context['type'] ?? null;
+        return [
+            'symbol' => $symbol,
+            'books' => array_map(
+                fn ($book) => match ($type) {
+                    BitfinexType::TRADING => new BookTrading($symbol, $book),
+                    BitfinexType::FUNDING => new BookFunding($symbol, $book),
+                },
+                $content
+            ),
+        ];
+    }
+}

--- a/src/Http/Responses/Public/Transformers/CandlesTransformer.php
+++ b/src/Http/Responses/Public/Transformers/CandlesTransformer.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Http\Responses\Public\Transformers;
+
+use EwertonDaniel\Bitfinex\Entities\Candle;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Contracts\PublicTransformer;
+
+/**
+ * Maps candles payload to Candle list with metadata.
+ */
+
+class CandlesTransformer implements PublicTransformer
+{
+    /**
+     * @param array $context Contextual parameters.
+     * @param mixed $content Decoded response content.
+     * @return mixed Returns array{symbol,timeframe,section,candles}.
+     */
+    public function transform(array $context, mixed $content): mixed
+    {
+        $candles = [];
+        if (is_array($content)) {
+            if (isset($content[0]) && is_array($content[0])) {
+                $candles = array_map(fn ($row) => new Candle($row), $content);
+            } elseif (!empty($content)) {
+                $candles = [new Candle($content)];
+            }
+        }
+        return [
+            'symbol' => (string) $context['symbol'],
+            'timeframe' => (string) $context['timeframe'],
+            'section' => (string) $context['section'],
+            'candles' => $candles,
+        ];
+    }
+}

--- a/src/Http/Responses/Public/Transformers/DerivativesStatusTransformer.php
+++ b/src/Http/Responses/Public/Transformers/DerivativesStatusTransformer.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Http\Responses\Public\Transformers;
+
+use EwertonDaniel\Bitfinex\Entities\DerivativeStatus;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Contracts\PublicTransformer;
+
+/**
+ * Maps derivatives status list to entities.
+ */
+
+class DerivativesStatusTransformer implements PublicTransformer
+{
+    /**
+     * @param array $context Contextual parameters.
+     * @param mixed $content Decoded response content.
+     * @return mixed Returns array{keys, items: list<DerivativeStatus>}.
+     */
+    public function transform(array $context, mixed $content): mixed
+    {
+        return [
+            'keys' => $context['keys'] ?? [],
+            'items' => array_map(fn ($row) => new DerivativeStatus($row), $content),
+        ];
+    }
+}

--- a/src/Http/Responses/Public/Transformers/ForeignExchangeRateTransformer.php
+++ b/src/Http/Responses/Public/Transformers/ForeignExchangeRateTransformer.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Http\Responses\Public\Transformers;
+
+use EwertonDaniel\Bitfinex\Entities\ForeignExchangeRate;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Contracts\PublicTransformer;
+
+/**
+ * Maps FX rate payload to ForeignExchangeRate.
+ */
+
+class ForeignExchangeRateTransformer implements PublicTransformer
+{
+    /**
+     * @param array $context Contextual parameters.
+     * @param mixed $content Decoded response content.
+     * @return mixed Returns ForeignExchangeRate.
+     */
+    public function transform(array $context, mixed $content): mixed
+    {
+        return new ForeignExchangeRate((string) $context['in'], (string) $context['out'], $content);
+    }
+}

--- a/src/Http/Responses/Public/Transformers/FundingStatsTransformer.php
+++ b/src/Http/Responses/Public/Transformers/FundingStatsTransformer.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Http\Responses\Public\Transformers;
+
+use EwertonDaniel\Bitfinex\Entities\FundingStat;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Contracts\PublicTransformer;
+
+/**
+ * Maps funding stats rows to FundingStat.
+ */
+
+class FundingStatsTransformer implements PublicTransformer
+{
+    /**
+     * @param array $context Contextual parameters.
+     * @param mixed $content Decoded response content.
+     * @return mixed Returns array{symbol, items: list<FundingStat>}.
+     */
+    public function transform(array $context, mixed $content): mixed
+    {
+        return [
+            'symbol' => (string) $context['symbol'],
+            'items' => array_map(fn ($row) => new FundingStat($row), $content),
+        ];
+    }
+}

--- a/src/Http/Responses/Public/Transformers/LeaderboardsTransformer.php
+++ b/src/Http/Responses/Public/Transformers/LeaderboardsTransformer.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Http\Responses\Public\Transformers;
+
+use EwertonDaniel\Bitfinex\Entities\LeaderboardEntry;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Contracts\PublicTransformer;
+
+/**
+ * Maps leaderboard rows to LeaderboardEntry.
+ */
+
+class LeaderboardsTransformer implements PublicTransformer
+{
+    /**
+     * @param array $context Contextual parameters.
+     * @param mixed $content Decoded response content.
+     * @return mixed Returns array{key,timeframe,symbol,section,items}.
+     */
+    public function transform(array $context, mixed $content): mixed
+    {
+        return [
+            'key' => (string) $context['key'],
+            'timeframe' => (string) $context['timeframe'],
+            'symbol' => (string) $context['symbol'],
+            'section' => (string) $context['section'],
+            'items' => array_map(fn ($row) => new LeaderboardEntry($row), $content),
+        ];
+    }
+}

--- a/src/Http/Responses/Public/Transformers/LiquidationsTransformer.php
+++ b/src/Http/Responses/Public/Transformers/LiquidationsTransformer.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Http\Responses\Public\Transformers;
+
+use EwertonDaniel\Bitfinex\Entities\Liquidation;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Contracts\PublicTransformer;
+
+/**
+ * Normalizes liquidation rows and maps to Liquidation.
+ */
+
+class LiquidationsTransformer implements PublicTransformer
+{
+    /**
+     * @param array $context Contextual parameters.
+     * @param mixed $content Decoded response content.
+     * @return mixed Returns array{liquidations: list<Liquidation>}.
+     */
+    public function transform(array $context, mixed $content): mixed
+    {
+        $normalize = function ($row) {
+            if (is_array($row) && isset($row[0]) && is_array($row[0]) && count($row) === 1) {
+                $row = $row[0];
+            }
+            if (is_array($row) && isset($row[0]) && $row[0] === 'pos') {
+                return new Liquidation($row);
+            }
+            if (is_array($row) && count($row) >= 4) {
+                $posRow = ['pos', $row[0], $row[1], null, null, $row[2], $row[3], null, null, null, null, null];
+                return new Liquidation($posRow);
+            }
+            return new Liquidation($row);
+        };
+        return ['liquidations' => array_map($normalize, $content)];
+    }
+}

--- a/src/Http/Responses/Public/Transformers/MarketAveragePriceTransformer.php
+++ b/src/Http/Responses/Public/Transformers/MarketAveragePriceTransformer.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Http\Responses\Public\Transformers;
+
+use EwertonDaniel\Bitfinex\Entities\MarketAveragePriceResult;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Contracts\PublicTransformer;
+
+/**
+ * Maps market average price result.
+ */
+
+class MarketAveragePriceTransformer implements PublicTransformer
+{
+    /**
+     * @param array $context Contextual parameters.
+     * @param mixed $content Decoded response content.
+     * @return mixed Returns array{result: MarketAveragePriceResult}.
+     */
+    public function transform(array $context, mixed $content): mixed
+    {
+        return ['result' => new MarketAveragePriceResult($content)];
+    }
+}

--- a/src/Http/Responses/Public/Transformers/PlatformStatusTransformer.php
+++ b/src/Http/Responses/Public/Transformers/PlatformStatusTransformer.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Http\Responses\Public\Transformers;
+
+use EwertonDaniel\Bitfinex\Entities\PlatformStatus;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Contracts\PublicTransformer;
+
+/**
+ * Maps platform status [1]/[0] to entity.
+ */
+
+class PlatformStatusTransformer implements PublicTransformer
+{
+    /**
+     * @param array $context Contextual parameters.
+     * @param mixed $content Decoded response content.
+     * @return mixed Returns PlatformStatus.
+     */
+    public function transform(array $context, mixed $content): mixed
+    {
+        return new PlatformStatus($content);
+    }
+}

--- a/src/Http/Responses/Public/Transformers/StatsTransformer.php
+++ b/src/Http/Responses/Public/Transformers/StatsTransformer.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Http\Responses\Public\Transformers;
+
+use EwertonDaniel\Bitfinex\Entities\Stat;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Contracts\PublicTransformer;
+
+/**
+ * Maps public stats payload to Stat entities with metadata.
+ */
+
+class StatsTransformer implements PublicTransformer
+{
+    /**
+     * @param array $context Contextual parameters.
+     * @param mixed $content Decoded response content.
+     * @return mixed Returns array{key,size,symPlatform,sidePair,section,stats}.
+     */
+    public function transform(array $context, mixed $content): mixed
+    {
+        return [
+            'key' => (string) $context['key'],
+            'size' => (string) $context['size'],
+            'symPlatform' => (string) $context['symPlatform'],
+            'sidePair' => (string) $context['sidePair'],
+            'section' => (string) $context['section'],
+            'stats' => array_map(fn ($data) => new Stat($data), $content),
+        ];
+    }
+}

--- a/src/Http/Responses/Public/Transformers/TickerHistoryTransformer.php
+++ b/src/Http/Responses/Public/Transformers/TickerHistoryTransformer.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Http\Responses\Public\Transformers;
+
+use EwertonDaniel\Bitfinex\Entities\TickerHistory;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Contracts\PublicTransformer;
+
+/**
+ * Groups ticker history by pair.
+ */
+
+class TickerHistoryTransformer implements PublicTransformer
+{
+    /**
+     * @param array $context Contextual parameters.
+     * @param mixed $content Decoded response content.
+     * @return mixed Returns array<string, list<TickerHistory>>.
+     */
+    public function transform(array $context, mixed $content): mixed
+    {
+        return collect($content)
+            ->map(fn ($history) => new TickerHistory($history))
+            ->groupBy('pair')
+            ->toArray();
+    }
+}

--- a/src/Http/Responses/Public/Transformers/TickerTransformer.php
+++ b/src/Http/Responses/Public/Transformers/TickerTransformer.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Http\Responses\Public\Transformers;
+
+use EwertonDaniel\Bitfinex\Entities\FundingCurrency;
+use EwertonDaniel\Bitfinex\Entities\TradingPair;
+use EwertonDaniel\Bitfinex\Enums\BitfinexType;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Contracts\PublicTransformer;
+
+/**
+ * Maps single ticker array to TradingPair/FundingCurrency.
+ */
+
+class TickerTransformer implements PublicTransformer
+{
+    /**
+     * @param array $context Contextual parameters.
+     * @param mixed $content Decoded response content.
+     * @return mixed Returns array{ticker: TradingPair|FundingCurrency}.
+     */
+    public function transform(array $context, mixed $content): mixed
+    {
+        $symbol = (string) ($context['symbol'] ?? '');
+        $type = $context['type'] ?? null;
+
+        $ticker = match ($type) {
+            BitfinexType::TRADING => new TradingPair($symbol, $content),
+            BitfinexType::FUNDING => new FundingCurrency($symbol, $content),
+        };
+
+        return ['ticker' => $ticker];
+    }
+}

--- a/src/Http/Responses/Public/Transformers/TickersTransformer.php
+++ b/src/Http/Responses/Public/Transformers/TickersTransformer.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Http\Responses\Public\Transformers;
+
+use EwertonDaniel\Bitfinex\Entities\FundingCurrency;
+use EwertonDaniel\Bitfinex\Entities\TradingPair;
+use EwertonDaniel\Bitfinex\Enums\BitfinexType;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Contracts\PublicTransformer;
+
+/**
+ * Maps list of tickers to entities by type.
+ */
+
+class TickersTransformer implements PublicTransformer
+{
+    /**
+     * @param array $context Contextual parameters.
+     * @param mixed $content Decoded response content.
+     * @return mixed Returns array{tickers: list<TradingPair|FundingCurrency>}.
+     */
+    public function transform(array $context, mixed $content): mixed
+    {
+        $type = $context['type'] ?? null;
+        return [
+            'tickers' => array_map(
+                fn ($ticker) => match ($type) {
+                    BitfinexType::TRADING => new TradingPair($ticker[0], array_slice($ticker, 1)),
+                    BitfinexType::FUNDING => new FundingCurrency($ticker[0], array_slice($ticker, 1)),
+                },
+                $content
+            ),
+        ];
+    }
+}

--- a/src/Http/Responses/Public/Transformers/TradesTransformer.php
+++ b/src/Http/Responses/Public/Transformers/TradesTransformer.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Http\Responses\Public\Transformers;
+
+use EwertonDaniel\Bitfinex\Entities\CurrencyTrade;
+use EwertonDaniel\Bitfinex\Entities\PairTrade;
+use EwertonDaniel\Bitfinex\Enums\BitfinexType;
+use EwertonDaniel\Bitfinex\Http\Responses\Public\Contracts\PublicTransformer;
+
+/**
+ * Maps trade rows to PairTrade/CurrencyTrade.
+ */
+
+class TradesTransformer implements PublicTransformer
+{
+    /**
+     * @param array $context Contextual parameters.
+     * @param mixed $content Decoded response content.
+     * @return mixed Returns array{trades: list<PairTrade|CurrencyTrade>}.
+     */
+    public function transform(array $context, mixed $content): mixed
+    {
+        $symbol = (string) ($context['symbol'] ?? '');
+        $type = $context['type'] ?? null;
+        return [
+            'trades' => array_map(
+                fn ($trade) => match ($type) {
+                    BitfinexType::TRADING => new PairTrade($symbol, $trade),
+                    BitfinexType::FUNDING => new CurrencyTrade($symbol, $trade),
+                },
+                $content
+            ),
+        ];
+    }
+}

--- a/src/Services/Authenticated/BitfinexAuthenticatedMerchants.php
+++ b/src/Services/Authenticated/BitfinexAuthenticatedMerchants.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EwertonDaniel\Bitfinex\Services\Authenticated;
+
+use EwertonDaniel\Bitfinex\Builders\RequestBuilder;
+use EwertonDaniel\Bitfinex\Builders\UrlBuilder;
+use EwertonDaniel\Bitfinex\Exceptions\BitfinexPathNotFoundException;
+use EwertonDaniel\Bitfinex\Http\Requests\BitfinexRequest;
+use EwertonDaniel\Bitfinex\Http\Responses\AuthenticatedBitfinexResponse;
+use EwertonDaniel\Bitfinex\ValueObjects\BitfinexCredentials;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+
+/**
+ * Merchants (Bitfinex Pay) authenticated endpoints.
+ *
+ * This service wraps the `private.merchants` endpoints defined in resources/paths.json.
+ * Methods accept payload arrays to keep flexibility with the API contract.
+ */
+class BitfinexAuthenticatedMerchants
+{
+    private readonly string $basePath;
+
+    public function __construct(
+        private readonly UrlBuilder $url,
+        private readonly BitfinexCredentials $credentials,
+        private readonly RequestBuilder $request,
+        private readonly Client $client
+    ) {
+        $this->basePath = 'private.merchants';
+    }
+
+    /**
+     * Create a Merchant invoice.
+     *
+     * @throws GuzzleException
+     * @throws BitfinexPathNotFoundException
+     */
+    final public function submitInvoice(array $payload): AuthenticatedBitfinexResponse
+    {
+        $this->request->setBody($payload);
+        $request = new BitfinexRequest($this->request, $this->credentials, $this->client);
+        $response = $request->execute(apiPath: $this->url->setPath("$this->basePath.submit_invoice")->getPath());
+
+        return $response->merchantInvoiceCreated();
+    }
+
+    /**
+     * Create a POS (Point of Sale) invoice.
+     *
+     * @throws GuzzleException
+     * @throws BitfinexPathNotFoundException
+     */
+    final public function submitPostInvoice(array $payload): AuthenticatedBitfinexResponse
+    {
+        $this->request->setBody($payload);
+        $request = new BitfinexRequest($this->request, $this->credentials, $this->client);
+        $response = $request->execute(apiPath: $this->url->setPath("$this->basePath.submit_post_invoice")->getPath());
+
+        return $response->merchantPostInvoiceCreated();
+    }
+
+    /**
+     * List invoices (non‑paginated, optional filters).
+     */
+    final public function invoiceList(array $filters = []): AuthenticatedBitfinexResponse
+    {
+        $this->request->setBody($filters);
+        $request = new BitfinexRequest($this->request, $this->credentials, $this->client);
+        $response = $request->execute(apiPath: $this->url->setPath("$this->basePath.invoice_list")->getPath());
+
+        return $response->merchantInvoiceList();
+    }
+
+    /**
+     * Paginated list of invoices (page/pageSize + optional filters).
+     */
+    final public function invoiceListPaginated(int $page = 1, int $pageSize = 30, array $filters = []): AuthenticatedBitfinexResponse
+    {
+        $body = array_merge(['page' => $page, 'pageSize' => $pageSize], $filters);
+        $this->request->setBody($body);
+        $request = new BitfinexRequest($this->request, $this->credentials, $this->client);
+        $response = $request->execute(apiPath: $this->url->setPath("$this->basePath.invoice_list_paginated")->getPath());
+
+        return $response->merchantInvoiceListPaginated();
+    }
+
+    /**
+     * Invoices count statistics (optional filters).
+     */
+    final public function invoiceCountStats(array $filters = []): AuthenticatedBitfinexResponse
+    {
+        $this->request->setBody($filters);
+        $request = new BitfinexRequest($this->request, $this->credentials, $this->client);
+        $response = $request->execute(apiPath: $this->url->setPath("$this->basePath.invoice_count_stats")->getPath());
+
+        return $response->merchantInvoiceCountStats();
+    }
+
+    /**
+     * Invoices earnings statistics (optional filters).
+     */
+    final public function invoiceEarningsStats(array $filters = []): AuthenticatedBitfinexResponse
+    {
+        $this->request->setBody($filters);
+        $request = new BitfinexRequest($this->request, $this->credentials, $this->client);
+        $response = $request->execute(apiPath: $this->url->setPath("$this->basePath.invoice_earnings_stats")->getPath());
+
+        return $response->merchantInvoiceEarningsStats();
+    }
+
+    /**
+     * Mark an invoice as completed.
+     */
+    final public function completeInvoice(array $payload): AuthenticatedBitfinexResponse
+    {
+        $this->request->setBody($payload);
+        $request = new BitfinexRequest($this->request, $this->credentials, $this->client);
+        $response = $request->execute(apiPath: $this->url->setPath("$this->basePath.complete_invoice")->getPath());
+
+        return $response->merchantInvoiceCompleted();
+    }
+
+    /**
+     * Expire an invoice.
+     */
+    final public function expireInvoice(array $payload): AuthenticatedBitfinexResponse
+    {
+        $this->request->setBody($payload);
+        $request = new BitfinexRequest($this->request, $this->credentials, $this->client);
+        $response = $request->execute(apiPath: $this->url->setPath("$this->basePath.expire_invoice")->getPath());
+
+        return $response->merchantInvoiceExpired();
+    }
+
+    /**
+     * List configured currency conversions.
+     */
+    final public function currencyConversionList(array $filters = []): AuthenticatedBitfinexResponse
+    {
+        $this->request->setBody($filters);
+        $request = new BitfinexRequest($this->request, $this->credentials, $this->client);
+        $response = $request->execute(apiPath: $this->url->setPath("$this->basePath.currency_Conversion_list")->getPath());
+
+        return $response->merchantCurrencyConversionList();
+    }
+
+    /**
+     * Add a new currency conversion.
+     */
+    final public function addCurrencyConversion(array $payload): AuthenticatedBitfinexResponse
+    {
+        $this->request->setBody($payload);
+        $request = new BitfinexRequest($this->request, $this->credentials, $this->client);
+        $response = $request->execute(apiPath: $this->url->setPath("$this->basePath.add_currency_conversion")->getPath());
+
+        return $response->merchantCurrencyConversionCreated();
+    }
+
+    /**
+     * Remove an existing currency conversion.
+     */
+    final public function removeCurrencyConversion(array $payload): AuthenticatedBitfinexResponse
+    {
+        $this->request->setBody($payload);
+        $request = new BitfinexRequest($this->request, $this->credentials, $this->client);
+        $response = $request->execute(apiPath: $this->url->setPath("$this->basePath.remove_currency_conversion")->getPath());
+
+        return $response->merchantCurrencyConversionRemoved();
+    }
+
+    /**
+     * Get merchant daily limit.
+     */
+    final public function merchantLimit(array $filters = []): AuthenticatedBitfinexResponse
+    {
+        $this->request->setBody($filters);
+        $request = new BitfinexRequest($this->request, $this->credentials, $this->client);
+        $response = $request->execute(apiPath: $this->url->setPath("$this->basePath.merchant_limit")->getPath());
+
+        return $response->merchantLimit();
+    }
+
+    /**
+     * Write merchant settings.
+     */
+    final public function merchantSettingsWrite(array $settings): AuthenticatedBitfinexResponse
+    {
+        $this->request->setBody($settings);
+        $request = new BitfinexRequest($this->request, $this->credentials, $this->client);
+        $response = $request->execute(apiPath: $this->url->setPath("$this->basePath.merchant_settings_write")->getPath());
+
+        return $response->merchantSettingsWrite();
+    }
+
+    /**
+     * Write merchant settings in batch.
+     */
+    final public function merchantSettingsWriteBatch(array $settings): AuthenticatedBitfinexResponse
+    {
+        $this->request->setBody($settings);
+        $request = new BitfinexRequest($this->request, $this->credentials, $this->client);
+        $response = $request->execute(apiPath: $this->url->setPath("$this->basePath.merchant_settings_write_batch")->getPath());
+
+        return $response->merchantSettingsWriteBatch();
+    }
+
+    /**
+     * Read merchant settings.
+     */
+    final public function merchantSettingsRead(array $filters = []): AuthenticatedBitfinexResponse
+    {
+        $this->request->setBody($filters);
+        $request = new BitfinexRequest($this->request, $this->credentials, $this->client);
+        $response = $request->execute(apiPath: $this->url->setPath("$this->basePath.merchant_settings_read")->getPath());
+
+        return $response->merchantSettingsRead();
+    }
+
+    /**
+     * List available merchant settings/keys.
+     */
+    final public function merchantSettingsList(array $filters = []): AuthenticatedBitfinexResponse
+    {
+        $this->request->setBody($filters);
+        $request = new BitfinexRequest($this->request, $this->credentials, $this->client);
+        $response = $request->execute(apiPath: $this->url->setPath("$this->basePath.merchant_settings_list")->getPath());
+
+        return $response->merchantSettingsList();
+    }
+
+    /**
+     * List deposits linked to merchant invoices.
+     */
+    final public function depositsList(array $filters = []): AuthenticatedBitfinexResponse
+    {
+        $this->request->setBody($filters);
+        $request = new BitfinexRequest($this->request, $this->credentials, $this->client);
+        $response = $request->execute(apiPath: $this->url->setPath("$this->basePath.deposits_list")->getPath());
+
+        return $response->merchantDepositsList();
+    }
+
+    /**
+     * List deposits not linked to merchant invoices.
+     */
+    final public function unlinkedDepositsList(array $filters = []): AuthenticatedBitfinexResponse
+    {
+        $this->request->setBody($filters);
+        $request = new BitfinexRequest($this->request, $this->credentials, $this->client);
+        $response = $request->execute(apiPath: $this->url->setPath("$this->basePath.unlinked_deposits_list")->getPath());
+
+        return $response->merchantUnlinkedDepositsList();
+    }
+}
+


### PR DESCRIPTION
### Summary of Changes

- Introduced multiple public transformers for handling endpoints such as `PlatformStatus`, `Ticker`, `Tickers`, `Candles`, `Book`, and `Trades`.
- Developed `PublicTransformer` contract ensuring consistency across mappings.
- Added `BitfinexAuthenticatedMerchants` service for merchant functionality, including invoice management, settings, deposits, and currency conversions.
- Updated `composer.lock` to reflect new dependencies.
- Enhanced configuration mappings with `ConfigsTransformer`.